### PR TITLE
Ajout de la personnalisation des animations, définition d'une emprise initiale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+stories/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-stories/

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Exemple :
 #### map 
 - configuration de la carte.
  * prototype 
-     **map.**`center`: ["coordonnées (web marcator) du centre de la carte"] (array)
+     **map.**`center`: ["coordonnées (web marcator) du centre de la carte "] (array)
      
 Exemple :
 ```
@@ -117,13 +117,20 @@ Exemple :
   }
 ```   
  * prototype 
-     **map.**`width`: "taille de la carte. (supprimé pour les version >1.0. La taille de la carte est calculée automatiquement selon le paramètre data.template.size)" 
+     **map.**`width`: "taille de la carte. (supprimé pour les version >1.0. La taille de la carte est calculée automatiquement selon le paramètre data.template.size)"
+
+ * prototype 
+     **map.**`initial_zoom`: "zoom (1 à 20)" (str)
+ * descriptif : niveau de zoom utilisé lors de l'initialisation de la carte (emprise initiale).
+
  * prototype 
      **map.**`zoom`: "zoom (1 à 20)" (str)
- * descriptif : zoom utilisé lors de l'initialisation de la carte et du zoom sur les entités géographiques.
+ * descriptif : niveau de zoom utilisé sur les entités géographiques.
+
 ```
   {
-  "zoom": "12"
+  "zoom": "12",
+  "initial_zoom":"8",
   }
 ```  
  * prototype 
@@ -151,10 +158,29 @@ Exemple :
  
  * prototype 
      **map.**`animation`: "true" (booleen)
-     
- * descriptif : Activation ou désactivation de l'animation de zoom lors d'un changement de focus sur les entités géographiques.
- * exemple {animation "false"}
- 
+
+  * descriptif : Activation ou désactivation de l'animation de zoom lors d'un changement de focus sur les entités géographiques.
+  * prototype 
+   **map.**`animation_duration_ms`:  "durée en millisecondes" (int)
+   * descriptif: durée en ms des animations, la durée par défaut est 2000ms.
+
+  * Si l'animation est activée, une petite animation s'éxecute au début à partir du point `center` vers `initial_view_center`.
+  
+  * prototype 
+     **map.**`initial_view_center`:  ["coordonnées (web marcator) du centre de la carte après l'animation initiale"] (array)
+
+ Exemple :
+```
+  {
+  "center":[200000,5171222],
+  "zoom":12,
+  ...
+  "animation": "true",
+  "animation_duration_ms": 1000,
+  "initial_view_center":[837716, 6191230]
+  }
+```   
+
 #### data - configuration du contenu de la storymap.
  * prototype 
      **data.**`title`: "Titre de la story" (str)

--- a/README.md
+++ b/README.md
@@ -120,23 +120,17 @@ Exemple :
      **map.**`width`: "taille de la carte. (supprimé pour les version >1.0. La taille de la carte est calculée automatiquement selon le paramètre data.template.size)"
 
  * prototype 
-     **map.**`initial_zoom`: "zoom (1 à 20)" (str)
- * descriptif : niveau de zoom utilisé lors de l'initialisation de la carte (emprise initiale).
-
- * prototype 
      **map.**`zoom`: "zoom (1 à 20)" (str)
- * descriptif : niveau de zoom utilisé sur les entités géographiques.
+    * descriptif : niveau de zoom utilisé sur les entités géographiques.
 
 ```
   {
   "zoom": "12",
-  "initial_zoom":"8",
   }
 ```  
  * prototype 
      **map.**`overview`: "true" (booleen)
-     
- * descriptif : Permet d'afficher ou de masquer la mini carte de localisation.
+     * descriptif : Permet d'afficher ou de masquer la mini carte de localisation.
  
  Exemple :
 ```
@@ -145,9 +139,8 @@ Exemple :
   }
 ```   
  * prototype 
-     **map.**`url`: "url" (str)
-     
- * descriptif : fond carto à utiliser OSM par exemple.
+    **map.**`url`: "url" (str)
+    * descriptif : fond carto à utiliser OSM par exemple.
  
  Exemple :
 ```
@@ -156,18 +149,21 @@ Exemple :
   }
 ```   
  
- * prototype 
-     **map.**`animation`: "true" (booleen)
-
-  * descriptif : Activation ou désactivation de l'animation de zoom lors d'un changement de focus sur les entités géographiques.
   * prototype 
-   **map.**`animation_duration_ms`:  "durée en millisecondes" (int)
-   * descriptif: durée en ms des animations, la durée par défaut est 2000ms.
+      **map.**`animation`: "true" (booleen)
+    * descriptif : Activation ou désactivation de l'animation de zoom lors d'un changement de focus sur les entités géographiques.
 
-  * Si l'animation est activée, une petite animation s'éxecute au début à partir du point `center` vers `initial_view_center`.
-  
   * prototype 
-     **map.**`initial_view_center`:  ["coordonnées (web marcator) du centre de la carte après l'animation initiale"] (array)
+    **map.**`animation_duration_ms`:  "durée en millisecondes" (int)
+    * descriptif: durée en ms des animations, la durée par défaut est 2000ms.
+
+  * prototype 
+     **map.**`initial_zoom`: "zoom (1 à 20)" (str)
+    * descriptif : niveau de zoom utilisé lors de l'initialisation de la carte (emprise initiale). Paramètre pris en compte uniquement si **map.**`animation` est activé ("true").
+
+  * prototype 
+     **map.**`initial_view_center`:  ["coordonnées (web marcator)"] (array)
+     * descriptif : coordonnées (web marcator) du centre de la carte après l'animation initiale. Paramètre pris en compte uniquement si **map.**`animation` est activé ("true").
 
  Exemple :
 ```
@@ -219,8 +215,7 @@ Exemple :
  
  * prototype 
      **data.**`url`: "" (str)
- 
- * descriptif : URl vers la source de données. La source de données doit être au format geojson avec une projection EPSG:3857.
+    * descriptif : URl vers la source de données. La source de données doit être au format geojson avec une projection EPSG:3857.
    Il peut s'agir d'un fichier statique ou d'une flux WFS.
 
  Exemple 1 :
@@ -252,9 +247,7 @@ Exemple :
  
  * prototype 
      **data.**`orderby`: "" (str)
-     
- * descriptif : Ce paramètre permet de réordonner (ordre croissant) les entités géographiques sur la base d'un champ possédant des valeurs de type numérique.   
- Via ce paramètre, il est possible de décider du séquencage du contenu de la story. Le champ peut être présent dans le fichier csv associé.
+      * descriptif : Ce paramètre permet de réordonner (ordre croissant) les entités géographiques sur la base d'un champ possédant des valeurs de type numérique.   Via ce paramètre, il est possible de décider du séquencage du contenu de la story. Le champ peut être présent dans le fichier csv associé.
   
  Exemple :
 ```

--- a/js/storymap.js
+++ b/js/storymap.js
@@ -267,8 +267,6 @@ ks = (function() {
             view: new ol.View({
                 center: options.map.center,
                 zoom: options.map.initial_zoom || options.map.zoom
-                /* uncomment this code to have a small effect in the very begining*/
-                //zoom: options.map.zoom
             })
         });
         

--- a/templates/carousel.js
+++ b/templates/carousel.js
@@ -81,7 +81,7 @@ templates.carousel = function(dom, div) {
         // Show iframe in popup on click
         $("#panel-story .iframe-popup").click(function(){ks.popupIframe($(this).attr("src"))});
         var el = $("[data-bs-slide-to='0']");
-        ks.zoomTo(el.attr("data-position").split(",").map(Number), el.attr("id"), el.attr("data-featureid"), panel_width());
+        ks.zoomTo(el.attr("data-position").split(",").map(Number), el.attr("id"), el.attr("data-featureid"), panel_width(),true);
         _setProgress(parseInt(1 / $(".item").length * 100));
         //play audio if exists
         if (_audioAutoplay) {            


### PR DESCRIPTION
Cette PR introduit la possibilité de:
- définir une emprise initiale sur la carte #34 
- choisir la durée des animations entre entités

### Evolutions :
#### 1. Ajout de 3 champs optionnels dans le champ "map" du fichier config.json:
- _animation_duration_ms_
-  _initial_zoom_
-  _initial_view_center_
#### 2. Mise à jour de la doc
 

### Changements à réaliser dans les storymaps actuelles :
- Aucun, en l'absence de ces champs, la storymap se comporte comme avant