### PR TITLE
Add public fonction to return map and add name to layer #38

### DIFF
--- a/js/storymap.js
+++ b/js/storymap.js
@@ -319,6 +319,7 @@ ks = (function() {
             }
             vectorLayer = new ol.layer.Vector({
                 source: vectorSource,
+                name:'layerStorie',
                 style: _style
             });
             _map.addLayer(vectorLayer);
@@ -513,6 +514,10 @@ ks = (function() {
             _zoomTo(coordinates, item, featureid, offset,first_animation);
         },
         
+        mapStorie: function (){
+            return _map;
+        },
+
         menuaction: function (action) {
             event.preventDefault();            
             switch (action) {


### PR DESCRIPTION
Cette PR contient les évolutions suivantes : 
- Ajout d'un nom générique pour la couche OL contenant les données de la storymap (permet de la différencier et d'y accéder parmi les fonds de plan ..)
- Ajout d'une fonction publique pour accéder à la carte de la storymap

Ces évolutions répondent à un besoin dans le cadre d'un projet avec @hsquividant mais restent génériques et peuvent être réutilisées dans le cadre d'autres projets pour modifier la carte à la volée 